### PR TITLE
Screeps egg now useable despite some issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish Docker Image to GHCR
 
 on:
   push:
-    branches: [ "trunk" ]
+    branches: ["trunk", "test"]
 
 jobs:
   build_and_push:
@@ -12,19 +12,25 @@ jobs:
       packages: write
 
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-    - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and Push Docker Image
-      uses: docker/build-push-action@v5
-      with:
-        context: ./screeps
-        push: true
-        tags: ghcr.io/${{ github.repository }}:latest
+      - name: Extract metadata (tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./screeps
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -6,19 +6,23 @@ Wraps [screepers/screeps-launcher](https://github.com/screepers/screeps-launcher
 
 - At the moment only the default game and cli ports are supported. I'm not sure how to change the game port with `screeps-launcher`.
 
+- The "stop" command doesn't appear to work in Pterodactyl? I'm not sure how to fix this at the moment but the server will start and appears to work fine.
+
 ## Pterodactyl Configuration
 
 ### Variables
-- `STEAM_KEY`: **(Required)** variable must be set to your steam API key.
+
+- `STEAM_KEY`: **(Required)** variable must be set to your [steam API key](https://steamcommunity.com/dev/apikey).
 - `MODS_LIST` variable set to a comma separated list of mods to include in the server. These should be formatted like you would find on [screeps-launcher repo](https://github.com/screepers/screeps-launcher/tree/main). E.g. `screepsmod-auth,screepsmod-admin-utils,...`.
 - `BOTS_LIST` variable set to a comma separate list of bots to include in the server. These also should be formatted like you would fine on [screeps-launcher repo](https://github.com/screepers/screeps-launcher/tree/main). E.g. `simplebot: screepsbot-zeswarm,...`.
-- `WELCOME_TEXT` only required if using the `screepsmod-admin-utils` mod. Sets the servers welcome text. It should be `html` formatted. E.g. `<h1 style="text-align: center;">Screeps Server</h1>`.
+- `WELCOME_TEXT` only required if using the `screepsmod-admin-utils` mod. Sets the servers welcome text. It should be `html` formatted. E.g. `<h1 style="text-align: center;">Screeps Server</h1>`. **This seems broken right now and not formatted right in Pterodactyl variables. Have not gotten around to fixing it.**
 - `TICK_RATE` only required if using the `screepsmod-admin-utils` mod. Sets the server tick rate in milliseconds.
 - `MONGO_HOST`, `MONGO_PORT`, `REDIS_HOST`, `REDIS_PORT` only required if using the `screepsmod-mongo` mod. If so, make sure to check the below "Mod Notes" section.
 
 ### Mod Notes
 
 #### screepsmod-mongo
+
 If using `screepsmod-mongo`, then you must setup a `mongodb` and `redis` server. A docker compose configuration already exists for this in the `database` directory of the repo. Steps to run are:
 
 1. Clone the repo. Move into the `database` directory.
@@ -28,17 +32,45 @@ If using `screepsmod-mongo`, then you must setup a `mongodb` and `redis` server.
 3. Run `sudo docker-compose up -d` or `docker compose up -d`, depending on your compose version, to launch the services.
 
 4. Get the docker IP with `ip a show docker0`. In this example it is `172.17.0.1`.
+
 ```
-6: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
+6: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
     link/ether ...
     inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
        valid_lft forever preferred_lft forever
-    inet6 .../64 scope link proto kernel_ll 
+    inet6 .../64 scope link proto kernel_ll
        valid_lft forever preferred_lft forever
 ```
 
 5. Make sure to set the `screepsmod-mongo` related variables in Pterodactyl. For this example it would be:
+
 - `MONGO_HOST`: `172.17.0.1`
 - `MONGO_PORT`: `27017`
 - `REDIS_HOST`: `172.17.0.1`
 - `REDIS_PORT`: `6379`
+
+**IMPORTANT** After a server is running. You need to reset all data (this only needs to be done once). At the moment the Pterodactyl console is read-only. I couldn't figure out how to get the cli to work as well so in the meantime to do this:
+
+1. Connect to the screeps server host.
+
+2. Use `docker container list` to find the name/id of the screeps container.
+
+3. Use `docker exec -it <screeps container name> /bin/bash` to enter the docker container.
+
+4. Run `screeps-launcher cli` to start the CLI connection.
+
+5. Run `system.resetAllData()`.
+
+6. All done. Type `exit` to leave the CLI and again to leave the docker container. Again to exit ssh.
+
+#### screepsmod-map-tool
+
+Right now the egg does not automatically configure the username and password for the `screepsmod-map-tool` mod. Once the server is installed this can be done manually by going to the server "Files". Edit the `.screepsrc` file. Add the following to the end:
+
+```
+[maptool]
+user = <user>
+pass = <password>
+```
+
+Restart the server and you should be able to login now.

--- a/egg-screeps.json
+++ b/egg-screeps.json
@@ -1,0 +1,123 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
+    },
+    "exported_at": "2025-07-15T23:20:59-06:00",
+    "name": "Screeps",
+    "author": "pterodactyl.relieving197@passmail.net",
+    "description": null,
+    "features": null,
+    "docker_images": {
+        "ghcr.io\/jkturcotte\/screeps-egg:latest": "ghcr.io\/jkturcotte\/screeps-egg:latest",
+        "ghcr.io\/jkturcotte\/screeps-egg:test": "ghcr.io\/jkturcotte\/screeps-egg:test"
+    },
+    "file_denylist": [],
+    "startup": "\/entrypoint.sh",
+    "config": {
+        "files": "{}",
+        "startup": "{\r\n    \"done\": \"Started\"\r\n}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": null,
+            "container": "alpine:3.4",
+            "entrypoint": "ash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Steam Key",
+            "description": "https:\/\/steamcommunity.com\/dev\/apikey",
+            "env_variable": "STEAM_KEY",
+            "default_value": "",
+            "user_viewable": false,
+            "user_editable": true,
+            "rules": "required|string",
+            "field_type": "text"
+        },
+        {
+            "name": "Mods List",
+            "description": "Comma separated list of mods to include. E.g. `screepsmod-auth, screepsmod-admin-utils, ...`.\r\nhttps:\/\/github.com\/ScreepsMods\r\n\r\nSpecial setup is required if using the `screepsmod-mongo` mod.\r\nhttps:\/\/github.com\/jkturcotte\/screeps-egg",
+            "env_variable": "MODS_LIST",
+            "default_value": "screepsmod-auth, screepsmod-admin-utils",
+            "user_viewable": false,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "Bots List",
+            "description": "A comma separated list\/dictionary format of bots to include.\r\nE.g. `simplebot: screepsbot-zeswarm, ...`\r\n`simplebot` is the name of the AI in the server and `screepsbot-zeswarm` is the A.I that the screeps-launcher recognizes.\r\n\r\nAnything bot supported by the screeps-launcher should work but I couldn't find a list.\r\nhttps:\/\/github.com\/screepers\/screeps-launcher",
+            "env_variable": "BOTS_LIST",
+            "default_value": "simplebot: screepsbot-zeswarm",
+            "user_viewable": false,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "Welcome Text",
+            "description": "The welcome text for the server. Requires `screepsmod-admin-utils`. Also seems broken right now. Seems the variable doesn't support some characters you may want to use in an HTML formatted welcome text.",
+            "env_variable": "WELCOME_TEXT",
+            "default_value": "",
+            "user_viewable": false,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "Tick Rate",
+            "description": "Tick rate in milliseconds. Requires the `screepsmod-admin-utils` mod.",
+            "env_variable": "TICK_RATE",
+            "default_value": "1000",
+            "user_viewable": false,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "Mongo Host",
+            "description": "Mongo host IP when using the `screepsmod-mongo` mod.",
+            "env_variable": "MONGO_HOST",
+            "default_value": "",
+            "user_viewable": false,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "MONGO_PORT",
+            "description": "Mongo port when using the `screepsmod-mongo` mod.",
+            "env_variable": "MONGO_PORT",
+            "default_value": "27017",
+            "user_viewable": false,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "Redis Host",
+            "description": "Redis host IP when using the `screepsmod-mongo` mod.",
+            "env_variable": "REDIS_HOST",
+            "default_value": "",
+            "user_viewable": false,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "Redis Port",
+            "description": "Redis port when using the `screepsmod-mongo` mod.",
+            "env_variable": "REDIS_PORT",
+            "default_value": "6379",
+            "user_viewable": false,
+            "user_editable": true,
+            "rules": "string",
+            "field_type": "text"
+        }
+    ]
+}

--- a/screeps/Dockerfile
+++ b/screeps/Dockerfile
@@ -1,17 +1,16 @@
-FROM node:12-alpine
+FROM ghcr.io/screepers/screeps-launcher:main
+
+ENTRYPOINT []
 
 USER root
 RUN adduser --disabled-password --home /home/container container
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && chown container:container /entrypoint.sh
-RUN npm install screeps && npm screeps init
 
 USER container
 ENV USER=container HOME=/home/container
 
 WORKDIR /home/container
-
-
 
 CMD ["/bin/bash", "/entrypoint.sh"]

--- a/screeps/Dockerfile
+++ b/screeps/Dockerfile
@@ -1,12 +1,11 @@
-FROM ghcr.io/screepers/screeps-launcher:main
-
-ENTRYPOINT []
+FROM node:12-alpine
 
 USER root
 RUN adduser --disabled-password --home /home/container container
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && chown container:container /entrypoint.sh
+RUN npm install screeps && npm screeps init
 
 USER container
 ENV USER=container HOME=/home/container

--- a/screeps/entrypoint.sh
+++ b/screeps/entrypoint.sh
@@ -37,7 +37,7 @@ if [[ -n "${WELCOME_TEXT}" || -n "${TICK_RATE}" ]]; then
     if [[ -n "${WELCOME_TEXT}" ]]; then
         echo "  welcomeText:  |" >> $CONFIG_FILE
         while IFS= read -r line; do
-            echo"    ${line}" >> $CONFIG_FILE
+            echo "    ${line}" >> $CONFIG_FILE
         done <<< "$WELCOME_TEXT"
     fi
 


### PR DESCRIPTION
- Adjusted workflow to publish both a test & latest version of the image so I can test things without breaking the image made on `trunk`.
- Updated `README.md` with additional information.
- Added an exported copy of the Screeps egg to the repo.

There are some issues:
- Pterodactyl console is not interactive. Need to go to the docker container directly and run `screeps-launcher cli` to run any commands. I haven't figured out how to fix this yet.
- Server can't be stopped easily. Pterodactyl will just wait forever. Until this is fixed, the server must be killed after pressing "Stop" or "Restart".